### PR TITLE
Adding RunSafe Protections

### DIFF
--- a/nginx-hello-nonroot/html-version/Dockerfile
+++ b/nginx-hello-nonroot/html-version/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:mainline-alpine
+FROM runsafesecurity-docker-alkemist-repo.jfrog.io/nginx:mainline-alpine
 
 # We need to give all user groups write permission on folder /var/cache/nginx/ and file /var/run/nginx.pid.
 # So users with random uid will be able to run NGINX.

--- a/nginx-hello-nonroot/plain-text-version/Dockerfile
+++ b/nginx-hello-nonroot/plain-text-version/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:mainline-alpine
+FROM runsafesecurity-docker-alkemist-repo.jfrog.io/nginx:mainline-alpine
 
 # We need to give all user groups write permission on folder /var/cache/nginx/ and file /var/run/nginx.pid.
 # So users with random uid will be able to run NGINX.

--- a/nginx-hello/Dockerfile
+++ b/nginx-hello/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:mainline-alpine
+FROM runsafesecurity-docker-alkemist-repo.jfrog.io/nginx:mainline-alpine
 RUN rm /etc/nginx/conf.d/*
 ADD hello.conf /etc/nginx/conf.d/
 ADD index.html /usr/share/nginx/html/

--- a/nginx-hello/DockerfilePlainText
+++ b/nginx-hello/DockerfilePlainText
@@ -1,3 +1,3 @@
-FROM nginx:mainline-alpine
+FROM runsafesecurity-docker-alkemist-repo.jfrog.io/nginx:mainline-alpine
 RUN rm /etc/nginx/conf.d/*
 ADD hello-plain-text.conf /etc/nginx/conf.d/

--- a/nginx-regex-tester/regextester/Dockerfile
+++ b/nginx-regex-tester/regextester/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:latest
+FROM runsafesecurity-docker-alkemist-repo.jfrog.io/nginx:latest
 
 COPY start.sh /usr/local/sbin
 RUN chmod +x /usr/local/sbin/start.sh

--- a/nginx-swarm-demo/hello/Dockerfile
+++ b/nginx-swarm-demo/hello/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM runsafesecurity-docker-alkemist-repo.jfrog.io/nginx
 RUN rm /etc/nginx/conf.d/*
 COPY hello.conf /etc/nginx/conf.d
 copy content /usr/share/nginx/html

--- a/nginx-swarm-demo/nginxbasic/Dockerfile
+++ b/nginx-swarm-demo/nginxbasic/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM runsafesecurity-docker-alkemist-repo.jfrog.io/nginx
 
 # copy the cert and key
 COPY swarmdemo.selfcrt /root/swarmdemo.crt

--- a/random-files/backend/Dockerfile
+++ b/random-files/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM runsafesecurity-docker-alkemist-repo.jfrog.io/nginx
 MAINTAINER Nick Shadrin <nick@nginx.com>
 
 COPY ./start.sh /usr/share/nginx/html/start.sh


### PR DESCRIPTION
This auto-generated MR replaces uses of open-sources packages with their RunSafe-protected equivalents.

See https://alkemist.runsafesecurity.com for more information.